### PR TITLE
broadcaster-context-with-split-share-listen

### DIFF
--- a/fastapi_websocket_pubsub/event_broadcaster.py
+++ b/fastapi_websocket_pubsub/event_broadcaster.py
@@ -1,6 +1,5 @@
 import asyncio
 from typing import Any, Union
-from asyncio.exceptions import InvalidStateError
 from pydantic.main import BaseModel
 from .event_notifier import EventNotifier, Subscription, TopicList, ALL_TOPICS
 from broadcaster import Broadcast

--- a/fastapi_websocket_pubsub/event_broadcaster.py
+++ b/fastapi_websocket_pubsub/event_broadcaster.py
@@ -79,10 +79,10 @@ class EventBroadcasterContextManager:
                     # if this was last listener - we can stop the reading task
                     if self._event_broadcaster._listen_count == 0:
                         # Cancel task reading broadcast subscriptions
-                        if self._subscription_task is not None:
+                        if self._event_broadcaster._subscription_task is not None:
                             logger.info("Cancelling broadcast listen task")
-                            self._subscription_task.cancel()
-                            self._subscription_task = None
+                            self._event_broadcaster._subscription_task.cancel()
+                            self._event_broadcaster._subscription_task = None
 
                 if self._share:
                     self._event_broadcaster._share_count -= 1     

--- a/fastapi_websocket_pubsub/event_broadcaster.py
+++ b/fastapi_websocket_pubsub/event_broadcaster.py
@@ -29,7 +29,7 @@ class BroadcasterAlreadyStarted(EventBroadcasterException):
     pass
 
 
-class EventBroadcasterContextManger:
+class EventBroadcasterContextManager:
     """
     Manages the context for the EventBroadcaster
     Friend-like class of EventBroadcaster (accessing "protected" members )
@@ -170,7 +170,7 @@ class EventBroadcaster:
         return await self._notifier.unsubscribe(self._id)
 
     def get_context(self, listen=True, share=True):
-        return EventBroadcasterContextManger(self, listen=listen, share=share )
+        return EventBroadcasterContextManager(self, listen=listen, share=share )
                                     
     async def __aenter__(self):
         """

--- a/fastapi_websocket_pubsub/event_broadcaster.py
+++ b/fastapi_websocket_pubsub/event_broadcaster.py
@@ -170,7 +170,23 @@ class EventBroadcaster:
         return await self._notifier.unsubscribe(self._id)
 
     def get_context(self, listen=True, share=True):
-        return EventBroadcasterContextManager(self, listen=listen, share=share )
+        """
+        Create a new context manager you can call 'async with' on, configuring the broadcaster for listening, sharing, or both.
+
+        Args:
+            listen (bool, optional): Should we listen for events incoming from the broadcast channel. Defaults to True.
+            share (bool, optional): Should we share events with the broadcast channel. Defaults to True.
+
+        Returns:
+            EventBroadcasterContextManager: the context 
+        """
+        return EventBroadcasterContextManager(self, listen=listen, share=share)
+
+    def get_listening_context(self):
+        return EventBroadcasterContextManager(self, listen=True, share=False)
+                                  
+    def get_sharing_context(self):
+        return EventBroadcasterContextManager(self, listen=False, share=True)
                                     
     async def __aenter__(self):
         """

--- a/fastapi_websocket_pubsub/event_broadcaster.py
+++ b/fastapi_websocket_pubsub/event_broadcaster.py
@@ -56,7 +56,7 @@ class EventBroadcasterContextManger:
                 self._event_broadcaster._listen_count += 1
                 if self._event_broadcaster._listen_count == 1:
                     # We have our first listener start the read-task for it (And all those who'd follow)
-                    logger.info("Listening for incoming events from broadcaster (first listener started)")
+                    logger.info("Listening for incoming events from broadcast channel (first listener started)")
                     # Start task listening on incoming broadcasts
                     self._event_broadcaster.start_reader_task()
 
@@ -66,7 +66,7 @@ class EventBroadcasterContextManger:
                     # We have our first publisher
                     # Init the broadcast used for sharing (reading has its own)
                     self._event_broadcaster._acquire_publishing_broadcast()                
-                    logger.info("Subscribing to ALL TOPICS, to share with broadcast channel")
+                    logger.info("Subscribing to ALL TOPICS, and sharing messages with broadcast channel")
                     # Subscribe to internal events form our own event notifier and broadcast them
                     await self._event_broadcaster._subscribe_to_all_topics()
 
@@ -181,7 +181,7 @@ class EventBroadcaster:
 
 
     async def __aexit__(self, exc_type, exc, tb):
-        self.get_context().__aexit__(exc_type, exc, tb)
+        self._context_manager.__aexit__(exc_type, exc, tb)
 
     def start_reader_task(self):
         """Spawn a task reading incoming broadcasts and posting them to the intreal notifier

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-fastapi-websocket-rpc>=0.1.17
+fastapi-websocket-rpc>=0.1.18
 broadcaster==0.2.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='fastapi_websocket_pubsub',
-    version='0.1.16',
+    version='0.1.17',
     author='Or Weis',
     author_email="or@authorizon.com",
     description="A fast and durable PubSub channel over Websockets (using fastapi-websockets-rpc).",


### PR DESCRIPTION
Allow seperate contexts for brodcaster share/listen 